### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,15 +1,27 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
-    "default": ["{projectRoot}/src/**/*"],
-    "production": ["default", "!{projectRoot}/src/**/*.test.{ts,tsx,js,jsx}"]
+    "default": [
+      "{projectRoot}/src/**/*"
+    ],
+    "production": [
+      "default",
+      "!{projectRoot}/src/**/*.test.{ts,tsx,js,jsx}"
+    ]
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "cache": true,
-      "inputs": ["production", "^production"],
-      "outputs": ["{projectRoot}/dist/**"]
+      "inputs": [
+        "production",
+        "^production"
+      ],
+      "outputs": [
+        "{projectRoot}/dist/**"
+      ]
     }
   },
   "plugins": [
@@ -19,5 +31,6 @@
         "targetName": "lint"
       }
     }
-  ]
+  ],
+  "nxCloudId": "698767c3a554a970c7d8db46"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/698767c0172833ab2de25c1b/workspaces/698767c3a554a970c7d8db46

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.